### PR TITLE
[FEAT] 비밀번호 수정 api 구현

### DIFF
--- a/src/main/java/hobbiedo/user/auth/global/api/code/status/ErrorStatus.java
+++ b/src/main/java/hobbiedo/user/auth/global/api/code/status/ErrorStatus.java
@@ -22,7 +22,8 @@ public enum ErrorStatus implements BaseErrorCode {
 	FIND_LOGIN_ID_FAIL(HttpStatus.BAD_REQUEST, "MEMBER406", "회원 아이디 찾기에 실패했습니다"),
 	RESET_PASSWORD_FAIL(HttpStatus.BAD_REQUEST, "MEMBER407", "회원 비밀번호 찾기에 실패했습니다"),
 	LOGOUT_FAIL(HttpStatus.BAD_REQUEST, "MEMBER408", "로그아웃 실패"),
-	EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER408", "이메일을 찾을 수 없습니다.");
+	EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER409", "이메일을 찾을 수 없습니다."),
+	NOT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER410", "기존 비밀번호가 일치하지 않습니다");
 
 	private final HttpStatus httpStatus;
 	private final String status;

--- a/src/main/java/hobbiedo/user/auth/global/api/code/status/SuccessStatus.java
+++ b/src/main/java/hobbiedo/user/auth/global/api/code/status/SuccessStatus.java
@@ -18,6 +18,7 @@ public enum SuccessStatus implements BaseCode {
 	EMAIL_AUTH_MATCH(HttpStatus.OK, "MEMBER200", "이메일 인증 코드가 일치합니다."),
 	CAN_USE_LOGIN_ID(HttpStatus.OK, "MEMBER200", "사용할 수 있는 아이디입니다."),
 	LOGOUT_SUCCESS(HttpStatus.OK, "MEMBER200", "로그아웃 성공"),
+	UPDATE_PASSWORD_SUCCESS(HttpStatus.OK, "MEMBER200", "비밀번호 변경 성공"),
 	REISSUE_TOKEN_SUCCESS(HttpStatus.OK, "MEMBER200", "액세스/리프레시 토큰 재발급에 성공했습니다");
 	private final HttpStatus httpStatus;
 	private final String status;

--- a/src/main/java/hobbiedo/user/auth/member/application/MemberService.java
+++ b/src/main/java/hobbiedo/user/auth/member/application/MemberService.java
@@ -12,6 +12,7 @@ import hobbiedo.user.auth.member.domain.IntegrateAuth;
 import hobbiedo.user.auth.member.domain.Member;
 import hobbiedo.user.auth.member.dto.request.IntegrateSignUpDTO;
 import hobbiedo.user.auth.member.dto.request.ResetPasswordDTO;
+import hobbiedo.user.auth.member.dto.request.UpdatePasswordDTO;
 import hobbiedo.user.auth.member.infrastructure.MemberRepository;
 import hobbiedo.user.auth.member.vo.response.CheckLoginIdVO;
 import hobbiedo.user.auth.member.vo.response.SignUpVO;
@@ -43,7 +44,7 @@ public class MemberService {
 
 	@Transactional
 	public hobbiedo.user.auth.member.dto.response.ResetPasswordDTO resetPassword(ResetPasswordDTO resetPasswordDTO) {
-		validatePassword(resetPasswordDTO);
+		validateMember(resetPasswordDTO);
 		return hobbiedo.user.auth.member.dto.response.ResetPasswordDTO.builder()
 			.email(resetPasswordDTO.getEmail())
 			.tempPassword(updatePassword(resetPasswordDTO))
@@ -60,6 +61,26 @@ public class MemberService {
 			.build();
 	}
 
+	@Transactional
+	public void update(UpdatePasswordDTO updatePasswordDTO) {
+		validatePassword(updatePasswordDTO);
+		String newPassword = updatePasswordDTO.getNewPassword();
+		memberRepository.updatePasswordByUuid(
+			passwordEncoder.encode(newPassword),
+			updatePasswordDTO.getUuid());
+	}
+
+	private void validatePassword(UpdatePasswordDTO updatePasswordDTO) {
+		String currentPassword = updatePasswordDTO.getCurrentPassword();
+		String uuid = updatePasswordDTO.getUuid();
+
+		String encoded = memberRepository.findPasswordByUuid(uuid);
+		if (!passwordEncoder.matches(currentPassword, encoded)) {
+			throw new MemberExceptionHandler(ErrorStatus.NOT_MATCH_PASSWORD);
+		}
+
+	}
+
 	private void validateLoginId(IntegrateSignUpDTO integrateSignUpDTO) {
 		if (memberRepository.existsByMember_Email(integrateSignUpDTO.getEmail())) {
 			throw new MemberExceptionHandler(ErrorStatus.ALREADY_USE_EMAIL);
@@ -69,7 +90,7 @@ public class MemberService {
 		}
 	}
 
-	private void validatePassword(ResetPasswordDTO resetPasswordDTO) {
+	private void validateMember(ResetPasswordDTO resetPasswordDTO) {
 		Boolean isExist = memberRepository.existPasswordBy(
 			resetPasswordDTO.getName(),
 			resetPasswordDTO.getEmail(),

--- a/src/main/java/hobbiedo/user/auth/member/dto/request/UpdatePasswordDTO.java
+++ b/src/main/java/hobbiedo/user/auth/member/dto/request/UpdatePasswordDTO.java
@@ -1,0 +1,15 @@
+package hobbiedo.user.auth.member.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdatePasswordDTO {
+	private String uuid;
+	private String currentPassword;
+	private String newPassword;
+}

--- a/src/main/java/hobbiedo/user/auth/member/infrastructure/MemberRepository.java
+++ b/src/main/java/hobbiedo/user/auth/member/infrastructure/MemberRepository.java
@@ -34,5 +34,12 @@ public interface MemberRepository extends JpaRepository<IntegrateAuth, Long> {
 	@Query("UPDATE IntegrateAuth i SET i.password = :password WHERE i.loginId = :loginId")
 	void updatePasswordByLoginId(@Param("password") String password, @Param("loginId") String loginId);
 
+	@Modifying(clearAutomatically = true)
+	@Query("UPDATE IntegrateAuth i SET i.password = :password WHERE i.member.uuid = :uuid")
+	void updatePasswordByUuid(@Param("password") String password, @Param("uuid") String uuid);
+
+	@Query("SELECT i.password FROM IntegrateAuth i WHERE i.member.uuid = :uuid")
+	String findPasswordByUuid(@Param("uuid") String uuid);
+
 }
 

--- a/src/main/java/hobbiedo/user/auth/member/presentation/LoginMemberController.java
+++ b/src/main/java/hobbiedo/user/auth/member/presentation/LoginMemberController.java
@@ -1,6 +1,8 @@
 package hobbiedo.user.auth.member.presentation;
 
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -8,8 +10,12 @@ import org.springframework.web.bind.annotation.RestController;
 import hobbiedo.user.auth.global.api.ApiResponse;
 import hobbiedo.user.auth.global.api.code.status.SuccessStatus;
 import hobbiedo.user.auth.member.application.AuthService;
+import hobbiedo.user.auth.member.application.MemberService;
+import hobbiedo.user.auth.member.dto.request.UpdatePasswordDTO;
+import hobbiedo.user.auth.member.vo.request.UpdatePasswordVO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -17,9 +23,10 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 @RequestMapping("/v1/users")
 @RequiredArgsConstructor
-@Tag(name = "In-Members", description = "로그인한 사용자가 이용할 수 있는 서비스")
+@Tag(name = "Login-Members", description = "로그인한 사용자가 이용할 수 있는 서비스")
 public class LoginMemberController {
 	private final AuthService authService;
+	private final MemberService memberService;
 
 	@PostMapping("/logout")
 	@Operation(summary = "사용자 로그아웃",
@@ -28,6 +35,25 @@ public class LoginMemberController {
 		authService.logout(uuid);
 		return ApiResponse.onSuccess(
 			SuccessStatus.LOGOUT_SUCCESS,
+			null
+		);
+	}
+
+	@PatchMapping("/password")
+	@Operation(summary = "사용자 비밀번호 재설정",
+		description = "사용자의 비밀번호를 재설정합니다.")
+	public ApiResponse<Void> updatePasswordApi(
+		@RequestHeader(name = "Uuid") String uuid,
+		@Valid @RequestBody UpdatePasswordVO updatePasswordVO) {
+		UpdatePasswordDTO passwordDTO = UpdatePasswordDTO.builder()
+			.uuid(uuid)
+			.currentPassword(updatePasswordVO.getCurrentPassword())
+			.newPassword(updatePasswordVO.getNewPassword())
+			.build();
+
+		memberService.update(passwordDTO);
+		return ApiResponse.onSuccess(
+			SuccessStatus.UPDATE_PASSWORD_SUCCESS,
 			null
 		);
 	}

--- a/src/main/java/hobbiedo/user/auth/member/vo/request/UpdatePasswordVO.java
+++ b/src/main/java/hobbiedo/user/auth/member/vo/request/UpdatePasswordVO.java
@@ -1,0 +1,20 @@
+package hobbiedo.user.auth.member.vo.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Schema(description = "PatchPassword 요청 VO")
+public class UpdatePasswordVO {
+	@Schema(description = "기존 비밀번호")
+	private String currentPassword;
+	
+	@Schema(description = "새로운 비밀번호")
+	@Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}",
+		message = "비밀번호는 8~20자리 사이의 영어+숫자+특수문자로 이뤄져야합니다.")
+	private String newPassword;
+
+}


### PR DESCRIPTION
## 📣비밀번호 수정 api 구현
### 📅2024.5.31 
 ### 🌵Branch
feature/set-password → develop

### 📢 Description
비밀번호 변경 api를 만들었습니다.
제 마음대로, 일단 현재 비밀번호와 새 비밀번호를 받습니다.
그리고 현재 비밀번호를 검증합니다. 

### 💬Issue Number
[#feature/set-password] - develop

### 🛠️Type
- [x] 새로운 기능 추가 
- [ ] 버그 수정 
- [ ] CSS 등 사용자 UI 디자인 변경 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경) 
- [ ] 코드 리팩토링 
- [ ] 주석 추가 및 수정 
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링 
- [ ] 빌드 부분 혹은 패키지 매니저 수정 
- [ ] 파일 혹은 폴더명 수정 
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist 
PR이 다음 요구 사항을 충족하는지 확인하세요. 
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
(참고사항을 적어주세요)
