### PR TITLE
구글 로그인 시 회원판별 여부 조건 변경 및 기본 프로필 설정

### DIFF
--- a/src/main/java/hobbiedo/user/auth/google/application/GoogleService.java
+++ b/src/main/java/hobbiedo/user/auth/google/application/GoogleService.java
@@ -31,8 +31,7 @@ public class GoogleService {
 	@Transactional
 	public LoginResponseVO loginGoogle(GoogleLoginDTO googleLoginDTO) {
 		// 일반 회원인지 판별
-		Member member = googleMemberRepository.findByNameAndEmail(googleLoginDTO.getName(),
-				googleLoginDTO.getEmail())
+		Member member = googleMemberRepository.findByEmail(googleLoginDTO.getEmail())
 			.orElseThrow(() -> new MemberExceptionHandler(ErrorStatus.NO_EXIST_MEMBER));
 		// 구글 회원가입이 되어있지 않은 경우
 		if (!socialAuthRepository.existsByMember(member)) {

--- a/src/main/java/hobbiedo/user/auth/google/dto/request/GoogleSignUpDTO.java
+++ b/src/main/java/hobbiedo/user/auth/google/dto/request/GoogleSignUpDTO.java
@@ -39,12 +39,18 @@ public class GoogleSignUpDTO {
 	private GenderType gender;
 
 	@Schema(description = "가입 아이디, 8~20자리(영어+숫자), 특수문자 X")
+	@Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)[a-zA-Z\\d]{8,20}$",
+		message = "아이디는 8~20자리의 영어+숫자로만 이뤄져야합니다.(특수 문자x)")
 	private String loginId;
 
 	@Schema(description = "가입 비밀번호, 8 ~ 20자리(영어+숫자+특수문자")
+	@Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}",
+		message = "비밀번호는 8~20자리 사이의 영어+숫자+특수문자로 이뤄져야합니다.")
 	private String password;
 
 	@Schema(description = "가입자 생년월일, YYYY-mm-dd 형식만 허용")
+	@Pattern(regexp = "^(19|20)\\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$",
+		message = "생일은 yyyy-MM-dd 형식으로 이뤄져야합니다.")
 	private LocalDate birth;
 
 	public Member toMemberEntity() {

--- a/src/main/java/hobbiedo/user/auth/google/infrastructure/GoogleMemberRepository.java
+++ b/src/main/java/hobbiedo/user/auth/google/infrastructure/GoogleMemberRepository.java
@@ -7,7 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import hobbiedo.user.auth.member.domain.Member;
 
 public interface GoogleMemberRepository extends JpaRepository<Member, Long> {
-	Optional<Member> findByNameAndEmail(String name, String email);
-
-	Boolean existsByEmail(String email);
+	Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/hobbiedo/user/auth/google/presentation/GoogleController.java
+++ b/src/main/java/hobbiedo/user/auth/google/presentation/GoogleController.java
@@ -14,6 +14,7 @@ import hobbiedo.user.auth.member.vo.response.LoginResponseVO;
 import hobbiedo.user.auth.member.vo.response.SignUpVO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -27,7 +28,7 @@ public class GoogleController {
 	@Operation(summary = "구글 로그인",
 		description = "통합 회원이 아니면 에러를 return, 구글 회원이 아니면 구글 회원가입 후 로그인, 구글 회원이면 로그인")
 	@PostMapping("/login/google")
-	public ApiResponse<LoginResponseVO> googleLogin(@RequestBody GoogleLoginDTO googleLoginDTO) {
+	public ApiResponse<LoginResponseVO> googleLogin(@Valid @RequestBody GoogleLoginDTO googleLoginDTO) {
 		return ApiResponse.onSuccess(
 			SuccessStatus.GOOGLE_LOGIN_SUCCESS.getMessage(),
 			googleService.loginGoogle(googleLoginDTO));
@@ -35,7 +36,7 @@ public class GoogleController {
 
 	@Operation(summary = "구글 회원가입", description = "통합과 구글 회원가입 후, uuid return")
 	@PostMapping("/sign-up/google")
-	public ApiResponse<SignUpVO> googleSignUp(@RequestBody GoogleSignUpDTO googleSignUpDTO) {
+	public ApiResponse<SignUpVO> googleSignUp(@Valid @RequestBody GoogleSignUpDTO googleSignUpDTO) {
 		return ApiResponse.onSuccess(
 			SuccessStatus.GOOGLE_SIGN_UP_SUCCESS.getMessage(),
 			googleService.signUpGoogle(googleSignUpDTO));

--- a/src/main/java/hobbiedo/user/auth/member/domain/Member.java
+++ b/src/main/java/hobbiedo/user/auth/member/domain/Member.java
@@ -48,6 +48,6 @@ public class Member extends BaseEntity {
 	private String profileMessage = BLANK;
 
 	@Builder.Default
-	private String imageUrl = BLANK;
+	private String imageUrl = "https://hobbiedo-bucket.s3.ap-northeast-2.amazonaws.com/image_1718266148717_Frame%2010000";
 
 }


### PR DESCRIPTION
## 📣 구글 로그인 시 회원판별 여부 조건 변경 및 기본 프로필 설정
### 📅 2024.06.14
 
 ### 🌵Branch
feature/google  → develop

### 📢 Description
- 구글 로그인 시, 이미 회원인지 확인 조건을 (이름+이메일) -> (이메일) 으로 변경
- 회원 기본 프로필 URI 설정

### 💬Issue Number
[#26 ] - [FEAT] 구글 로그인, 회원가입 기능 구현 

### 🛠️Type
- [ ] 새로운 기능 추가 
- [ ] 버그 수정 
- [ ] CSS 등 사용자 UI 디자인 변경 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경) 
- [x] 코드 리팩토링 
- [ ] 주석 추가 및 수정 
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링 
- [ ] 빌드 부분 혹은 패키지 매니저 수정 
- [ ] 파일 혹은 폴더명 수정 
- [ ] 파일 혹은 폴더 삭제

