### PR TITLE
[FEAT] 타 회원 프로필 조회 기능 추가

### DIFF
--- a/src/main/java/hobbiedo/user/auth/global/api/ApiResponse.java
+++ b/src/main/java/hobbiedo/user/auth/global/api/ApiResponse.java
@@ -11,7 +11,7 @@ import hobbiedo.user.auth.global.api.code.BaseErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@JsonPropertyOrder({"isSuccess", "status", "data", "message"})
+@JsonPropertyOrder({"isSuccess", "status", "message", "data"})
 @Getter
 @AllArgsConstructor
 public class ApiResponse<T> {

--- a/src/main/java/hobbiedo/user/auth/global/api/code/status/SuccessStatus.java
+++ b/src/main/java/hobbiedo/user/auth/global/api/code/status/SuccessStatus.java
@@ -28,8 +28,9 @@ public enum SuccessStatus implements BaseCode {
 	// 회원 프로필 수정 성공
 	UPDATE_PROFILE_SUCCESS(HttpStatus.OK, "MEMBER200", "회원 프로필 이미지, 상태 메세지 수정 성공"),
 	// 회원 가입 정보 조회 성공
-	GET_SIGN_UP_PROFILE_SUCCESS(HttpStatus.OK, "MEMBER200", "회원 가입 정보 조회 성공");
-
+	GET_SIGN_UP_PROFILE_SUCCESS(HttpStatus.OK, "MEMBER200", "회원 가입 정보 조회 성공"),
+	// 타 회원 프로필 조회 성공
+	GET_OTHER_PROFILE_SUCCESS(HttpStatus.OK, "MEMBER200", "타 회원 프로필 조회 성공");
 	private final HttpStatus httpStatus;
 	private final String status;
 	private final String message;

--- a/src/main/java/hobbiedo/user/auth/member/presentation/ProfileController.java
+++ b/src/main/java/hobbiedo/user/auth/member/presentation/ProfileController.java
@@ -75,4 +75,18 @@ public class ProfileController {
 			SignUpProfileResponseVo.profileDtoToSignProfileVo(profileResponseDto)
 		);
 	}
+
+	// 다른 사용자 프로필 조회
+	@GetMapping("/member/other-profile")
+	@Operation(summary = "다른 사용자 프로필 조회", description = "다른 사용자의 프로필 상세 정보를 조회합니다.")
+	public ApiResponse<ProfileResponseVo> getOtherProfile(
+		@RequestHeader(name = "OtherUuid") String otherUuid) {
+
+		ProfileResponseDto profileResponseDto = profileService.getProfile(otherUuid);
+
+		return ApiResponse.onSuccess(
+			GET_OTHER_PROFILE_SUCCESS,
+			ProfileResponseVo.profileDtoToProfileVo(profileResponseDto)
+		);
+	}
 }


### PR DESCRIPTION
## 📣  회원 프로필 조회 기능 추가
### 📅 날짜 - 2024.06.19
 
 ### 🌵Branch
feature/profile  → develop

### 📢 Description
 타 회원 프로필 조회하는 api 의 헤더에 있는 uuid 를 사용하여 회원의 프로필을 조회한다

### 💬Issue Number
[#33 ] - 💫[FEAT] 타 회원 프로필 조회 기능 추가 #33

### 🛠️Type
- [x] 새로운 기능 추가 
- [ ] 버그 수정 
- [ ] CSS 등 사용자 UI 디자인 변경 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경) 
- [x] 코드 리팩토링 
- [ x 주석 추가 및 수정 
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링 
- [ ] 빌드 부분 혹은 패키지 매니저 수정 
- [ ] 파일 혹은 폴더명 수정 
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist 
PR이 다음 요구 사항을 충족하는지 확인하세요. 
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
**Swagger 를 사용하여 헤더에 다른 회원의 uuid 를 넣어 조회를 하였고, 조회가 되는 것을 확인하였다**
