### PR TITLE
[refactor] 구글 회원 가입 시, resquestDTO의 birth 필드 @patten 제거

### DIFF
--- a/src/main/java/hobbiedo/user/auth/google/dto/request/GoogleSignUpDTO.java
+++ b/src/main/java/hobbiedo/user/auth/google/dto/request/GoogleSignUpDTO.java
@@ -49,8 +49,6 @@ public class GoogleSignUpDTO {
 	private String password;
 
 	@Schema(description = "가입자 생년월일, YYYY-mm-dd 형식만 허용")
-	@Pattern(regexp = "^(19|20)\\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$",
-		message = "생일은 yyyy-MM-dd 형식으로 이뤄져야합니다.")
 	private LocalDate birth;
 
 	public Member toMemberEntity() {


### PR DESCRIPTION
## 📣 [refactor] 구글 회원 가입 시, resquestDTO의 birth 필드 @patten 제거
### 📅 2024.06.22
 
 ### 🌵Branch
feature/google  → develop

### 📢 Description
구글 회원 가입 시, resquestDTO의 birth 필드에서
LocalDate 과 @patten valid 충돌로 인한 @patten 제거

### 💬Issue Number
[#29 ]

### 🛠️Type
- [ ] 새로운 기능 추가 
- [ ] 버그 수정 
- [ ] CSS 등 사용자 UI 디자인 변경 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경) 
- [x] 코드 리팩토링 
- [ ] 주석 추가 및 수정 
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링 
- [ ] 빌드 부분 혹은 패키지 매니저 수정 
- [ ] 파일 혹은 폴더명 수정 
- [ ] 파일 혹은 폴더 삭제
